### PR TITLE
Fix per-person calculation

### DIFF
--- a/WeSplit/ContentView.swift
+++ b/WeSplit/ContentView.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
     // MARK: - Calculations
     var currentTip: Double {return Double(tipPercentages[selectedTipPercentage])}
     var orderAmount: Double {return Double(checkAmount) ?? 0}
-    var peopleCount: Double {return Double(numberOfPeople + 2)}
+    var peopleCount: Double {return Double(numberOfPeople)}
     var tipValue: Double {return (orderAmount/100) * currentTip }
     var total: Double {return orderAmount + tipValue}
     var totalPerPerson: Double {return total/peopleCount}


### PR DESCRIPTION
## Summary
- correct the formula for number of people so totals are right

## Testing
- `swiftc -o WeSplitApp WeSplit/ContentView.swift WeSplit/WeSplitApp.swift` *(fails: no such module 'SwiftUI')*